### PR TITLE
I can't repro, but if job's config does not contain a `.definition`, …

### DIFF
--- a/src/jenkins.ts
+++ b/src/jenkins.ts
@@ -166,6 +166,11 @@ class PipelineBuild {
 
         let root = parsed["flow-definition"];
 
+        // Issue #14 - can't repro, but this may fix
+        if (root.definition === undefined) {
+            root.definition = [{}];
+        }
+
         root.definition[0].script = script;
         root.quietPeriod = 0; // make sure job starts right away
 


### PR DESCRIPTION
…add a default one of `[{}]`